### PR TITLE
sbt 1.0 and PathFilter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,8 @@ project/plugins/project/
 # Idea
 .idea/
 .idea_modules/
+
+# Eclipse
+.classpath
+.project
+.settings

--- a/README.md
+++ b/README.md
@@ -49,3 +49,9 @@ includeFilter in filter := "*.js"
 
 excludeFilter in filter := "main.js"
 ```
+
+You can also remove a folder and all of its contents (including sub-folders). e.g. the "javascripts/working" folder and it contents with:
+
+```scala
+includeFilter in filter := PathFilter((sourceDirectory in Assets).value / "javascripts" / "working")
+```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For example, to remove the original CoffeeScript and LESS sources from the asset
 includeFilter in filter := "*.coffee" || "*.less"
 ```
 
-Alternatively, you may wish to remove all JavaScript files except the concatenated and minified main.js produce by
+Alternatively, you may wish to remove all JavaScript files except the concatenated and minified main.js produced by
 the RequireJS plugin:
 
 ```scala
@@ -50,7 +50,7 @@ includeFilter in filter := "*.js"
 excludeFilter in filter := "main.js"
 ```
 
-You can also remove a folder and all of its contents (including sub-folders). e.g. the "javascripts/working" folder and it contents with:
+You can also remove a folder and all of its contents (including sub-folders). e.g. the "javascripts/working" folder and its contents with:
 
 ```scala
 includeFilter in filter := PathFilter((sourceDirectory in Assets).value / "javascripts" / "working")

--- a/build.sbt
+++ b/build.sbt
@@ -4,9 +4,9 @@ organization := "com.slidingautonomy.sbt"
 
 name := "sbt-filter"
 
-version := "1.0.1"
+version := "1.0.2-SNAPSHOT"
 
-scalaVersion := "2.10.4"
+crossSbtVersions := Seq("1.0.2", "0.13.16")
 
 scalacOptions += "-feature"
 
@@ -18,11 +18,9 @@ resolvers ++= Seq(
   Resolver.mavenLocal
 )
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-js-engine" % "1.0.1")
+addSbtPlugin("com.typesafe.sbt" % "sbt-js-engine" % "1.2.2")
 
-scriptedSettings
-
-scriptedLaunchOpts <+= version apply { v => s"-Dproject.version=$v" }
+scriptedLaunchOpts += ("-Dproject.version=" + version.value)
 
 publishMavenStyle := true
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.5
+sbt.version=1.0.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,1 @@
-libraryDependencies <+= (sbtVersion) { sv =>
-  "org.scala-sbt" % "scripted-plugin" % sv
-}
+libraryDependencies += "org.scala-sbt" %% "scripted-plugin" % sbtVersion.value

--- a/src/main/scala/com/slidingautonomy/sbt/filter/SbtFilter.scala
+++ b/src/main/scala/com/slidingautonomy/sbt/filter/SbtFilter.scala
@@ -32,7 +32,10 @@ object SbtFilter extends AutoPlugin {
 
       val include = (includeFilter in filter).value
       val exclude = (excludeFilter in filter).value
-      mappings.filter(f => exclude.accept(f._1) || !include.accept(f._1) || f._2.startsWith("lib/"))
+      mappings.filter {
+        case (file, path) =>
+          !include.accept(file) || exclude.accept(file) || path.startsWith("lib" + java.io.File.separator)
+      }
   }
 
 }

--- a/src/main/scala/com/slidingautonomy/sbt/filter/SbtFilter.scala
+++ b/src/main/scala/com/slidingautonomy/sbt/filter/SbtFilter.scala
@@ -9,6 +9,21 @@ object Import {
 
   val filter = TaskKey[Pipeline.Stage]("filter", "Filter intermediate files on the asset pipeline.")
 
+  /** A FileFilter that selects all files/folders that exist within a `path`. Including the path. */
+  final case class PathFilter(path: java.nio.file.Path) extends FileFilter {
+
+    def accept(file: File): Boolean = file.toPath.startsWith(path)
+
+  }
+
+  object PathFilter {
+
+    def apply(path: String): PathFilter = apply(new File(path))
+
+    def apply(path: java.io.File): PathFilter = apply(path.toPath)
+
+  }
+
 }
 
 object SbtFilter extends AutoPlugin {

--- a/src/sbt-test/sbt-filter/directory/project/build.properties
+++ b/src/sbt-test/sbt-filter/directory/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.5

--- a/src/sbt-test/sbt-filter/directory/test
+++ b/src/sbt-test/sbt-filter/directory/test
@@ -1,5 +1,5 @@
 # Filter files.
 
-> web-stage
+> webStage
 -$ exists target/web/stage/temp/
 -$ exists target/web/stage/temp/x.coffee

--- a/src/sbt-test/sbt-filter/filter/project/build.properties
+++ b/src/sbt-test/sbt-filter/filter/project/build.properties
@@ -1,1 +1,0 @@
-sbt.version=0.13.5

--- a/src/sbt-test/sbt-filter/filter/test
+++ b/src/sbt-test/sbt-filter/filter/test
@@ -1,6 +1,6 @@
 # Filter files.
 
-> web-stage
+> webStage
 -$ exists target/web/stage/javascripts/x.coffee
 $ exists target/web/stage/javascripts/x.js
 -$ exists target/web/stage/javascripts/x.js.map

--- a/src/sbt-test/sbt-filter/path/build.sbt
+++ b/src/sbt-test/sbt-filter/path/build.sbt
@@ -1,0 +1,5 @@
+lazy val root = (project in file(".")).enablePlugins(SbtWeb)
+
+includeFilter in filter := PathFilter((sourceDirectory in Assets).value / "javascripts" / "working")
+
+pipelineStages := Seq(filter)

--- a/src/sbt-test/sbt-filter/path/project/plugins.sbt
+++ b/src/sbt-test/sbt-filter/path/project/plugins.sbt
@@ -1,0 +1,8 @@
+addSbtPlugin("com.slidingautonomy.sbt" % "sbt-filter" % sys.props("project.version"))
+
+resolvers ++= Seq(
+  Resolver.mavenLocal,
+  Resolver.url("sbt snapshot plugins", url("http://repo.scala-sbt.org/scalasbt/sbt-plugin-snapshots"))(Resolver.ivyStylePatterns),
+  Resolver.sonatypeRepo("snapshots"),
+  "Typesafe Snapshots Repository" at "http://repo.typesafe.com/typesafe/snapshots/"
+)

--- a/src/sbt-test/sbt-filter/path/src/main/assets/javascripts/working/a_core.js
+++ b/src/sbt-test/sbt-filter/path/src/main/assets/javascripts/working/a_core.js
@@ -1,0 +1,3 @@
+"use strict";
+
+const Core = {};

--- a/src/sbt-test/sbt-filter/path/src/main/assets/javascripts/working/b_menu.js
+++ b/src/sbt-test/sbt-filter/path/src/main/assets/javascripts/working/b_menu.js
@@ -1,0 +1,3 @@
+"use strict";
+
+const Menu = {};

--- a/src/sbt-test/sbt-filter/path/src/main/assets/javascripts/working/c_fields.js
+++ b/src/sbt-test/sbt-filter/path/src/main/assets/javascripts/working/c_fields.js
@@ -1,0 +1,3 @@
+"use strict";
+
+const Fields = {};

--- a/src/sbt-test/sbt-filter/path/src/main/assets/javascripts/x.coffee
+++ b/src/sbt-test/sbt-filter/path/src/main/assets/javascripts/x.coffee
@@ -1,0 +1,3 @@
+define ->
+  number   = 42
+  opposite = true

--- a/src/sbt-test/sbt-filter/path/src/main/assets/javascripts/x.js
+++ b/src/sbt-test/sbt-filter/path/src/main/assets/javascripts/x.js
@@ -1,0 +1,10 @@
+(function() {
+  define(function() {
+    var number, opposite;
+    number = 42;
+    return opposite = true;
+  });
+
+}).call(this);
+
+//# sourceMappingURL=x.js.map

--- a/src/sbt-test/sbt-filter/path/src/main/assets/javascripts/x.js.map
+++ b/src/sbt-test/sbt-filter/path/src/main/assets/javascripts/x.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "file": "x.js",
+  "sourceRoot": "",
+  "sources": [
+    "x.coffee"
+  ],
+  "names": [],
+  "mappings": "AAAA;AAAA,EAAA,MAAA,CAAO,SAAA,GAAA;AACL,QAAA,gBAAA;AAAA,IAAA,MAAA,GAAW,EAAX,CAAA;WACA,QAAA,GAAW,KAFN;EAAA,CAAP,CAAA,CAAA;AAAA"
+}

--- a/src/sbt-test/sbt-filter/path/src/main/assets/lib/vendor/x.coffee
+++ b/src/sbt-test/sbt-filter/path/src/main/assets/lib/vendor/x.coffee
@@ -1,0 +1,3 @@
+define ->
+  number   = 42
+  opposite = true

--- a/src/sbt-test/sbt-filter/path/src/main/assets/lib/vendor/x.js
+++ b/src/sbt-test/sbt-filter/path/src/main/assets/lib/vendor/x.js
@@ -1,0 +1,10 @@
+(function() {
+  define(function() {
+    var number, opposite;
+    number = 42;
+    return opposite = true;
+  });
+
+}).call(this);
+
+//# sourceMappingURL=x.js.map

--- a/src/sbt-test/sbt-filter/path/src/main/assets/lib/vendor/x.js.map
+++ b/src/sbt-test/sbt-filter/path/src/main/assets/lib/vendor/x.js.map
@@ -1,0 +1,10 @@
+{
+  "version": 3,
+  "file": "x.js",
+  "sourceRoot": "",
+  "sources": [
+    "x.coffee"
+  ],
+  "names": [],
+  "mappings": "AAAA;AAAA,EAAA,MAAA,CAAO,SAAA,GAAA;AACL,QAAA,gBAAA;AAAA,IAAA,MAAA,GAAW,EAAX,CAAA;WACA,QAAA,GAAW,KAFN;EAAA,CAAP,CAAA,CAAA;AAAA"
+}

--- a/src/sbt-test/sbt-filter/path/test
+++ b/src/sbt-test/sbt-filter/path/test
@@ -1,0 +1,16 @@
+# Filter path.
+
+> webStage
+# Path is filtered
+-$ exists target/web/stage/javascripts/working
+-$ exists target/web/stage/javascripts/working/a_core.js
+-$ exists target/web/stage/javascripts/working/b_menu.js
+-$ exists target/web/stage/javascripts/working/c_fields.js
+# Others are not filtered
+$ exists target/web/stage/javascripts/x.coffee
+$ exists target/web/stage/javascripts/x.js
+$ exists target/web/stage/javascripts/x.js.map
+# Modules in lib are not filtered
+$ exists target/web/stage/lib/vendor/x.coffee
+$ exists target/web/stage/lib/vendor/x.js
+$ exists target/web/stage/lib/vendor/x.js.map


### PR DESCRIPTION
Migrate to sbt 1.0.
Cross build for sbt 0.13.
I do not know how to update the Travis configuration.
Update the "lib" folder exclusion to use `java.io.File.separator` to also support Windows.
Add a `PathFilter`, a test and documentation.